### PR TITLE
fix: move if statement before the post method

### DIFF
--- a/pages/forms/TripForm/[id].js
+++ b/pages/forms/TripForm/[id].js
@@ -48,29 +48,28 @@ export default function EditFormPage() {
         ? `https://source.unsplash.com/random/?${repTripDataCountry}-${repTripDataCity}`
         : `https://source.unsplash.com/random/?${repTripDataCountry}`,
     };
-    try {
-      const response = await fetch(`/api/trips/${id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(editedTrip),
-      });
+    if (tripData.endDate < tripData.startDate) {
+      alert("The end date needs to be bigger than the start date!");
+    } else {
+      try {
+        const response = await fetch(`/api/trips/${id}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(editedTrip),
+        });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! Status: ${response.status}`);
-      }
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
 
-      if (tripData.endDate < tripData.startDate) {
-        alert("The end date needs to be bigger than the start date!");
-      } else {
         router.push(`/trip/${id}`);
+      } catch (error) {
+        console.error("Error updating trip:", error);
       }
-    } catch (error) {
-      console.error("Error updating trip:", error);
     }
   }
-
   return (
     <EditForm
       country={country}

--- a/pages/forms/TripForm/index.js
+++ b/pages/forms/TripForm/index.js
@@ -33,21 +33,22 @@ export default function TripFormPage() {
         : `https://source.unsplash.com/random/?${repTripDataCountry}`,
     };
 
-    const response = await fetch("/api/trips", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(newTrip),
-    });
-
-    if (!response.ok) {
-      console.error(response.status);
-      return;
-    }
     if (tripData.endDate < tripData.startDate) {
       alert("The end date needs to be bigger than the start date!");
     } else {
+      const response = await fetch("/api/trips", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newTrip),
+      });
+
+      if (!response.ok) {
+        console.error(response.status);
+        return;
+      }
+
       mutate();
       router.push("/");
     }


### PR DESCRIPTION
We moved the if-Statement, in both, the `forms/TripForm/[id].js` and `forms/TripForm/index.js` before the POST/PUT method, so that the wrong data will not be saved as a new or edited trip.